### PR TITLE
Change DB Connection

### DIFF
--- a/config/visitors.php
+++ b/config/visitors.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    // db connection
+    'connection' => 'mysql',
+];

--- a/src/Models/Visitor.php
+++ b/src/Models/Visitor.php
@@ -32,6 +32,12 @@ class Visitor extends Model
         'path',
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        $this->connection = config('visitors.connection');
+        parent::__construct($attributes);
+    }
+
     /**
      * Visit request
      * s

--- a/src/Providers/VisitorServiceProvider.php
+++ b/src/Providers/VisitorServiceProvider.php
@@ -29,7 +29,8 @@ class VisitorServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__ . "/../../database/2023_09_20_192335_create_visitors_table.php"
-            => database_path("migrations/2023_09_20_192335_create_visitors_table.php")
+                => database_path("migrations/2023_09_20_192335_create_visitors_table.php"),
+            __DIR__ . "/../../config/visitors.php" => config_path("visitors.php"),
         ], 'masoudi-laravel-visitors');
     }
 }


### PR DESCRIPTION
Some models can connect to different databases, but the `visitors` still connecting on the default DB connection. 
To solve this,  I've created the config file which contains the DB connection. With this, you can change this config on demand.

Controller:
```
config(['visitors.connection' => 'new_connection']);
$model->visit();
```